### PR TITLE
feat: setup API folder structure and implement server-side auth & user routes

### DIFF
--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: 'https://beckend-project-stork.onrender.com/api',
+  withCredentials: true,
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { parse } from 'cookie';
+import { api } from '../../api';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const apiRes = await api.post('auth/login', body);
+
+  const cookieStore = await cookies();
+  const setCookie = apiRes.headers['set-cookie'];
+
+  if (setCookie) {
+    const cookieArray = Array.isArray(setCookie) ? setCookie : [setCookie];
+    for (const cookieStr of cookieArray) {
+      const parsed = parse(cookieStr);
+      const options = {
+        expires: parsed.Expires ? new Date(parsed.Expires) : undefined,
+        path: parsed.Path,
+        maxAge: Number(parsed['Max-Age']),
+      };
+      if (parsed.refreshToken) cookieStore.set('refreshToken', parsed.refreshToken, options);
+    }
+
+    return NextResponse.json(apiRes.data);
+  }
+
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { api } from '../../api';
+
+export async function POST() {
+  const cookieStore = await cookies();
+
+  try {
+    const accessToken = cookieStore.get('accessToken')?.value;
+    const refreshToken = cookieStore.get('refreshToken')?.value;
+
+    await api.post('auth/logout', null, {
+      headers: {
+        Cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}`,
+      },
+    });
+
+    cookieStore.delete('accessToken');
+    cookieStore.delete('refreshToken');
+
+    return NextResponse.json({ message: 'Logged out successfully' });
+  } catch (error) {
+    console.error('Logout failed:', error);
+    return NextResponse.json({ error: 'Logout failed' }, { status: 500 });
+  }
+}

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { parse } from 'cookie';
+import { api } from '../../api';
+
+export async function GET(request: NextRequest) {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+  const next = request.nextUrl.searchParams.get('next') || '/';
+
+  if (refreshToken) {
+    const apiRes = await api.get('auth/refresh', {
+      headers: {
+        Cookie: cookieStore.toString(),
+      },
+    });
+    const setCookie = apiRes.headers['set-cookie'];
+    if (setCookie) {
+      const cookieArray = Array.isArray(setCookie) ? setCookie : [setCookie];
+      let refreshToken = '';
+
+      for (const cookieStr of cookieArray) {
+        const parsed = parse(cookieStr);
+        if (parsed.refreshToken) refreshToken = parsed.refreshToken;
+      }
+
+      if (refreshToken) cookieStore.set('refreshToken', refreshToken);
+
+      return NextResponse.redirect(new URL(next, request.url), {
+        headers: {
+          'set-cookie': cookieStore.toString(),
+        },
+      });
+    }
+  }
+  return NextResponse.redirect(new URL('/sign-in', request.url));
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { parse } from 'cookie';
+import { api } from '../../api';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const apiRes = await api.post('auth/register', body);
+
+  const cookieStore = await cookies();
+  const setCookie = apiRes.headers['set-cookie'];
+
+  console.log('API response headers:', apiRes.headers);
+  console.log('Set-Cookie header:', setCookie);
+
+  if (setCookie) {
+    const cookieArray = Array.isArray(setCookie) ? setCookie : [setCookie];
+    for (const cookieStr of cookieArray) {
+      const parsed = parse(cookieStr);
+
+      const options = {
+        expires: parsed.Expires ? new Date(parsed.Expires) : undefined,
+        path: parsed.Path,
+        maxAge: Number(parsed['Max-Age']),
+      };
+      if (parsed.refreshToken) cookieStore.set('refreshToken', parsed.refreshToken, options);
+    }
+    return NextResponse.json(apiRes.data);
+  }
+
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,43 @@
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { api } from '../api';
+import { cookies } from 'next/headers';
+
+export async function GET() {
+  const cookieStore = await cookies();
+  try {
+    const { data } = await api.get('/users', {
+      headers: {
+        Cookie: cookieStore.toString(),
+      },
+    });
+    if (data) return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const cookieStore = await cookies();
+    const body = await request.json();
+
+    const { data } = await api.patch('/users', body, {
+      headers: {
+        Cookie: cookieStore.toString(),
+      },
+    });
+
+    if (data) return NextResponse.json(data);
+
+    return NextResponse.json({ error: 'Failed to update user' }, { status: 500 });
+  } catch (error) {
+    console.log(error);
+    return NextResponse.json({ error: 'Failed to update user' }, { status: 500 });
+  }
+}
+
+export async function PUT() {
+  
+}


### PR DESCRIPTION
Create API folder structure under app/api for auth and users:

auth/login/route.ts

auth/logout/route.ts

auth/refresh/route.ts

auth/register/route.ts

users/route.ts

api.ts (axios client with withCredentials)

Implement server-side login, logout, refresh, and registration routes with cookie handling.

Implement GET and PATCH routes for user data.

Handle cookies using Next.js cookies() and cookie parser.