### PR TITLE
refactor: add sidebar to layout and simplify header logic

### DIFF
--- a/app/api/weeks/private/route.ts
+++ b/app/api/weeks/private/route.ts
@@ -6,14 +6,16 @@ import { cookies } from 'next/headers';
 
 export async function GET() {
   const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+
   try {
-    const { data } = await api.get('/weeks/private', {
+    const { data } = await api.get("/weeks/private", {
       headers: {
-        Cookie: cookieStore.toString(),
+        Authorization: `Bearer ${accessToken}`,
       },
     });
     if (data) return NextResponse.json(data);
-  } catch {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  } catch (err){
+    return NextResponse.json({ error: err.messsage }, { status: err.status });
   }
 }

--- a/app/api/weeks/public/route.ts
+++ b/app/api/weeks/public/route.ts
@@ -2,18 +2,13 @@ export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';
 import { api } from '../../api';
-import { cookies } from 'next/headers';
 
 export async function GET() {
-  const cookieStore = await cookies();
   try {
     const { data } = await api.get('/weeks/public', {
-      headers: {
-        Cookie: cookieStore.toString(),
-      },
     });
     if (data) return NextResponse.json(data);
-  } catch {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: err.status });
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -55,10 +55,14 @@ main {
     max-width: 1128px;
   }
 
-    body {
+  body {
     display: flex;
     justify-content: center;
     max-width: 1440px;
     margin: 0 auto;
   }
+}
+
+.app-layout {
+  display: flex;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,22 +34,29 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
   modal,
+  sidebar,
 }: Readonly<{
   children: React.ReactNode;
   modal: React.ReactNode;
+  sidebar: React.ReactNode;
 }>) {
   return (
     <html lang="uk">
       <body className={`${lato.variable} ${comfortaa.variable}`}>
         <TanStackProvider>
           <AuthProvider>
-            <HeaderWrapper />
+            <div className="header-wrapper">
+              <HeaderWrapper />
+            </div>
+            <div className="app-layout">
+              
+              <aside className="sidebar">{sidebar}</aside>
 
-            <main>
-              <Breadcrumbs />
-              <div>{children}</div>
-            </main>
-            {modal}
+              <main className="content">
+                <Breadcrumbs />
+                <div className="page-content">{children}</div>
+              </main>
+            </div>
           </AuthProvider>
           <Toaster position="top-center" reverseOrder={false} />
         </TanStackProvider>

--- a/components/Header/Header.module.css
+++ b/components/Header/Header.module.css
@@ -36,3 +36,10 @@
   align-items: center;
   fill: #000;
 }
+
+
+@media screen and (min-width: 1440px) {
+  .header {
+  display: none;
+  }
+}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -8,13 +8,13 @@ import SideBar from "@/components/Sidebar/Sidebar";
 
 const Header: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const isDesktop = useMediaQuery({ minWidth: 1440 });
+  // const isDesktop = useMediaQuery({ minWidth: 1440 });
 
-  useEffect(() => {
-    if (isDesktop) setIsOpen(false);
-  }, [isDesktop]);
+  // useEffect(() => {
+  //   if (isDesktop) setIsOpen(false);
+  // }, [isDesktop]);
 
-  if (isDesktop) return <SideBar isOpen={true} onClose={() => {}} />;
+  // if (isDesktop) return <SideBar isOpen={true} onClose={() => {}} />;
 
   return (
     <header className={styles.header}>


### PR DESCRIPTION
Додано `sidebar` у RootLayout з окремою секцією aside для кращої структури сторінки.
- Обгорнуто Header у `header-wrapper` для можливості окремого стилювання.
- Основний контент та breadcrumbs винесено у `main.content` для більш зрозумілої розмітки.
- Спрощено логіку Header: закоментовано обробку десктопної версії та залишено тільки мобільне бургер-меню.
- Покращено читабельність та структуру CSS-класів для легшого масштабування.