### PR TITLE
feat(modal): add close on Escape key, backdrop click, and prevent body scroll

### DIFF
--- a/app/(private router)/profile/page.module.css
+++ b/app/(private router)/profile/page.module.css
@@ -9,6 +9,6 @@
 
 @media screen and (min-width: 1440px) {
   .profileCard {
-    max-width: 644px;
+    max-width: 580px;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -67,7 +67,6 @@ main {
     display: flex;
     justify-content: center;
     max-width: 1440px;
-    margin: 0 auto;
   }
 
   .sidebar {

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -3,26 +3,31 @@
   flex-direction: column;
   gap: 16px;
 }
+
 .innerWrapper {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
+
 .firstWrapper {
   display: flex;
   flex-direction: column;
   gap: 24px;
 }
+
 .lastWrapper {
   display: flex;
   flex-direction: column;
   gap: 32px;
 }
+
 @media screen and (min-width: 768px) {
   .innerWrapper {
     gap: 32px;
   }
 }
+
 @media screen and (min-width: 1440px) {
   .innerWrapper {
     flex-direction: row;

--- a/components/Header/Header.module.css
+++ b/components/Header/Header.module.css
@@ -1,5 +1,7 @@
 .header {
-  width: 100%;
+  min-width: 320px;
+  max-width: 375px;
+  margin: 0 auto;
   height: 68px;
   padding: 0;
   background: #fff;
@@ -37,9 +39,15 @@
   fill: #000;
 }
 
+@media screen and (min-width: 768px) {
+  .header {
+    max-width: 768px;
+    padding: 16px 32px;
+  }
+}
 
 @media screen and (min-width: 1440px) {
   .header {
-  display: none;
+    display: none;
   }
 }

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -30,11 +30,10 @@ const Header = () => {
           </svg>
         </button>
       </div>
-      {/* {isOpen && ( */}
-        <HeaderModal isOpen={isOpen}>
-          <Sidebar onClose={close}/>
-        </HeaderModal>
-      {/* )} */}
+
+      <HeaderModal onClose={close} isOpen={isOpen}>
+        <Sidebar onClose={close} />
+      </HeaderModal>
     </header>
   );
 };

--- a/components/ProfileAvatar/ProfileAvatar.module.css
+++ b/components/ProfileAvatar/ProfileAvatar.module.css
@@ -61,7 +61,7 @@
   .wrap {
     display: flex;
     gap: 12px;
-    width: 100%;
+    width: 704px;
     align-items: center;
   }
 

--- a/components/Sidebar/Sidebar.module.css
+++ b/components/Sidebar/Sidebar.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  height: 100vh;
 }
 
 .header {

--- a/components/modals/HeaderModal/HeaderModal.tsx
+++ b/components/modals/HeaderModal/HeaderModal.tsx
@@ -7,10 +7,31 @@ import css from "./HeaderModal.module.css";
 type HeaderModalProps = {
   children: React.ReactNode;
   isOpen: boolean;
+  onClose: () => void;
 };
 
-const HeaderModal = ({ children, isOpen }: HeaderModalProps) => {
+const HeaderModal = ({ children, isOpen, onClose }: HeaderModalProps) => {
   const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.code === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
 
   useEffect(() => {
     setMounted(true);
@@ -19,7 +40,7 @@ const HeaderModal = ({ children, isOpen }: HeaderModalProps) => {
   if (!mounted) return null;
 
   return createPortal(
-    <div className={`${css.backdrop} ${isOpen ? css.open : ""}`}>
+    <div className={`${css.backdrop} ${isOpen ? css.open : ""}`} onClick={handleBackdropClick}>
       <div className={css.modalWrap}>{children}</div>
     </div>,
     document.body


### PR DESCRIPTION
- Додано пропс `onClose` до HeaderModal для закриття модалки при натисканні клавіші Escape.
- Реалізовано закриття модалки при кліку на область бекдропу.
- Заблоковано прокрутку body, поки модалка відкрита, та відновлено при закритті.
- Забезпечено рендер модалки тільки на клієнтській стороні, щоб уникнути помилок SSR.
- Оновлено стилі для плавного відкривання та правильного відображення бекдропу.