### PR TITLE
fix(dashboard & journey): prevent infinite loops when setting currentWeek and navigating

### DIFF
--- a/app/(private router)/journey/page.tsx
+++ b/app/(private router)/journey/page.tsx
@@ -2,9 +2,19 @@
 
 import { useAuth } from "@/lib/store/authStore";
 import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
 
 export default function JourneyContainer() {
   const { currentWeek } = useAuth();
-  const router = useRouter()
-  router.push(`/journey/${currentWeek}`)
+  const router = useRouter();
+  const hasNavigated = useRef(false);
+
+  useEffect(() => {
+    if (currentWeek && !hasNavigated.current) {
+      router.push(`/journey/${currentWeek}`);
+      hasNavigated.current = true;
+    }
+  }, [currentWeek, router]);
+
+  return null;
 }

--- a/app/DashBoard.client.tsx
+++ b/app/DashBoard.client.tsx
@@ -35,7 +35,11 @@ const DashBoardClient = () => {
     enabled: isAuthenticated,
   });
 
-  setCurrentWeek(privateInfo?.currentWeek ?? 5);
+  useEffect(() => {
+    if (privateInfo?.currentWeek) {
+      setCurrentWeek(privateInfo.currentWeek);
+    }
+  }, [privateInfo, setCurrentWeek]);
 
   const { publicInfo } = useInfo();
 

--- a/lib/api/apiClient.ts
+++ b/lib/api/apiClient.ts
@@ -30,7 +30,7 @@ export const login = async (payload: LoginPayload): Promise<void> => {
   return res.data;
 };
 
-export const refresh = async () => {
+export const refresh = async (): Promise<void> => {
   const res = await nextServer.post("/auth/refresh");
 
   return res.data;


### PR DESCRIPTION
- Поточний тиждень (currentWeek) тепер встановлюється безпечно після завантаження даних
- Навігація у JourneyContainer виконується лише один раз