### PR TITLE
move emotions state to zustand store

### DIFF
--- a/app/DashBoard.client.tsx
+++ b/app/DashBoard.client.tsx
@@ -11,12 +11,24 @@ import { useEffect } from "react";
 import { useAuth } from "@/lib/store/authStore";
 import { WeekRes } from "@/types/babyState";
 import Breadcrumbs from "@/components/Breadcrumbs/Breadcrumbs";
+import { useEmotion } from "@/lib/store/emotionsStore";
+import { getEmotions } from "@/lib/api/apiClient";
 type Props = {
   weekInfo: WeekRes;
 };
 const l = "Мій день";
 const DashBoardClient = ({ weekInfo }: Props) => {
   const setCurrentWeek = useAuth((st) => st.setCurrentWeek);
+  const setEmotions = useEmotion((s) => s.setEmotions);
+  
+  useEffect(() => {
+    const loadEmotions = async () => {
+      const res = await getEmotions();
+      if (res) setEmotions(res);
+    };
+
+    loadEmotions();
+  }, [setEmotions]);
 
   useEffect(() => {
     if (weekInfo?.currentWeek) {

--- a/components/modals/AddDiaryEntryModal/AddDiaryEntryForm/AddDiaryEntryForm.tsx
+++ b/components/modals/AddDiaryEntryModal/AddDiaryEntryForm/AddDiaryEntryForm.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import css from "./AddDiaryEntryForm.module.css";
-import { createDiary, getEmotions, updateDiary } from "@/lib/api/apiClient";
+import { createDiary,  updateDiary } from "@/lib/api/apiClient";
 import toast from "react-hot-toast";
-import { Emotion } from "@/types/emotions";
 import { DiaryData } from "@/types/diaries";
 import { useQueryClient } from "@tanstack/react-query";
 import { validationDiarySchema } from "./validation";
 import CustomCheckBoxForm from "./CustomCheckBoxForm";
+import { useEmotion } from "@/lib/store/emotionsStore";
 
 interface Props {
   onClose: () => void;
@@ -18,20 +17,9 @@ interface Props {
 }
 
 export default function DiaryEntryForm({ onClose, diary, onSave }: Props) {
-  const [emotions, setEmotions] = useState<Emotion[]>([]);
   const queryClient = useQueryClient();
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await getEmotions();
-        setEmotions(data);
-      } catch (err) {
-        console.error("Помилка при завантаженні емоцій", err);
-      }
-    };
-    fetchData();
-  }, []);
+  const emotions = useEmotion((s) => s.emotions)
 
   return (
     <Formik

--- a/lib/store/emotionsStore.ts
+++ b/lib/store/emotionsStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { Emotion } from "@/types/emotions";
+
+type EmotionStore = {
+  emotions: Emotion[];
+  setEmotions: (emotions: Emotion[]) => void;
+};
+
+export const useEmotion = create<EmotionStore>((set) => ({
+  emotions: [],
+  setEmotions: (emotions: Emotion[]) => set({ emotions }),
+}));


### PR DESCRIPTION
Виніс стан емоцій із форми в окремий zustand store. 
Тепер головна сторінка завантажує емоції один раз, а форма просто їх використовує.