### PR TITLE
fix(diary-page): auto-select first diary on desktop and update on removal

### DIFF
--- a/app/(private router)/diary/DuaryPage.client.tsx
+++ b/app/(private router)/diary/DuaryPage.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import GreetingBlock from "@/components/GreetingBlock/GreetingBlock";
 import DiaryList from "@/components/DiaryList/DiaryList";
 import DiaryEntryDetails from "@/components/DiaryEntryDetails/DiaryEntryDetails";
@@ -31,7 +31,20 @@ export default function DiaryPageClient() {
     queryFn: () => getDiaries(),
   });
 
-  const diaryList = diaries ?? [];
+  const diaryList = useMemo(() => diaries ?? [], [diaries]);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+
+    if (diaryList.length === 0) {
+      setSelectedDiary(null);
+      return;
+    }
+
+    if (!selectedDiary || !diaryList.some((d) => d._id === selectedDiary._id)) {
+      setSelectedDiary(diaryList[0]);
+    }
+  }, [isDesktop, diaryList, selectedDiary]);
 
   if (isLoading) {
     return (

--- a/app/(private router)/diary/page.module.css
+++ b/app/(private router)/diary/page.module.css
@@ -25,12 +25,13 @@
 .detailsBlock {
   flex: 2;
   background: transparent;
-  min-height: 300px;
   border-radius: 32px;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: #ffcbd3 rgba(0, 0, 0, 0.2);
+  background-color: #fff4f6;
   height: 727px;
+  width: 643px;
 }
 
 .detailsBlock::-webkit-scrollbar {

--- a/components/DiaryEntryDetails/DiaryEntryDetails.module.css
+++ b/components/DiaryEntryDetails/DiaryEntryDetails.module.css
@@ -1,8 +1,8 @@
 .header {
   display: flex;
-  justify-content: flex-start; /* элементы прижаты влево */
-  align-items: flex-start; /* текст прижат к верхнему краю */
-  flex-direction: column; /* заголовок + дата друг под другом */
+  justify-content: flex-start;
+  align-items: flex-start; 
+  flex-direction: column;
   gap: 8px;
   margin-bottom: 12px;
 }
@@ -149,7 +149,7 @@
 
   .card {
     border-radius: 24px;
-    width: 683px;
+    width: 643px;
     margin: auto;
     height: 727px;
   }


### PR DESCRIPTION
- Додано автоматичний вибір першого запису у десктопній версії (>=1440px).
- Якщо видаляється обраний запис, обирається новий перший елемент списку.
- Використано useMemo для стабільного масиву diaryList та уникнення зайвих ререндерів.